### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,35 @@
-settings.py
+# Created by https://www.gitignore.io/api/angular
+# Edit at https://www.gitignore.io/?templates=angular
+
+### Angular ###
+## Angular ##
+# compiled output
+/dist
+/tmp
+/app/**/*.js
+/app/**/*.js.map
+
+# dependencies
+/node_modules
+/bower_components
+
+# IDEs and editors
+/.idea
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage/*
+/libpeerconnection.log
+npm-debug.log
+testem.log
+/typings
+
+# e2e
+/e2e/*.js
+/e2e/*.map
+
+#System Files
+.DS_Store
+
+# End of https://www.gitignore.io/api/angular


### PR DESCRIPTION
# Descripción
Agregamos al .gitignore soporte para Angular

- [ ] Frontend
- [ ] Backend
- [x] Configuración del server

# ¿Cómo puedo probar los cambios?
Por ejemplo, los archivos y la carpeta de configuraciones y entregables de angular ya no se suben al repo. Ver completo el archivo .gitignore.
